### PR TITLE
Allow hooks to run with set -o noclobber

### DIFF
--- a/lib/core/hook.sh
+++ b/lib/core/hook.sh
@@ -49,6 +49,7 @@ shellspec_call_hook() {
 shellspec_call_before_hooks() {
   [ $# -lt 2 ] && set -- "$1" 1
   eval "[ \"\$2\" -gt \"\$SHELLSPEC_BEFORE_$1_INDEX\" ] &&:" && return 0
+  [ -f "$SHELLSPEC_ERROR_FILE" ] && rm -f "$SHELLSPEC_ERROR_FILE"
   shellspec_call_hook "BEFORE_$1" "$2" 2>"$SHELLSPEC_ERROR_FILE" || return 1
   [ -s "$SHELLSPEC_ERROR_FILE" ] && return 1
   shellspec_call_before_hooks "$1" "$(($2 + 1))"
@@ -57,6 +58,7 @@ shellspec_call_before_hooks() {
 shellspec_call_after_hooks() {
   [ $# -lt 2 ] && eval "set -- \"\$1\" \"\$SHELLSPEC_AFTER_$1_INDEX\""
   [ "$2" -lt 1 ] && return 0
+  [ -f "$SHELLSPEC_ERROR_FILE" ] && rm -f "$SHELLSPEC_ERROR_FILE"
   shellspec_call_hook "AFTER_$1" "$2" 2>"$SHELLSPEC_ERROR_FILE" || return 1
   [ -s "$SHELLSPEC_ERROR_FILE" ] && return 1
   shellspec_call_after_hooks "$1" $(($2 - 1))


### PR DESCRIPTION
When a hook is defined in a nested Describe block, and one of its tests produces error output, any test in a subsequent Describe block that also contains a hook, fails with:

```
/bin/dash: 53: cannot create /tmp/shellspec.XXXXXXXXXXXX/1/error: File exists
```

This occurs when running something like this:
```sh
cat >script-that-sets-noclobber-to-yes.sh<<'EOF'
set -o noclobber
EOF

Describe 'Something'
  Include ./script-that-sets-noclobber-to-yes.sh

  Describe 'Something'
    setup() { :; }
    BeforeAll 'setup'

    errout() { printf error >&2; }
    It 'should produce error output'
      When call errout
      The error should equal 'error'
    End
  End

  Describe 'Something else'
    setup() { :; }
    BeforeAll 'setup'
    It 'should do something'
      When call true
      The status should be success
    End
  End
End
```

This simply removes any existing error file prior to overwriting it, which allows `noclobber` to be in effect while running a hook.